### PR TITLE
Version Bump

### DIFF
--- a/src/Scryfall.Client/Scryfall.Client.csproj
+++ b/src/Scryfall.Client/Scryfall.Client.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <ImplicitUsings>true</ImplicitUsings>
     <PackageId>Scryfall.Client</PackageId>
-    <Version>3.0.5</Version>
+    <Version>4.0.0-build.1</Version>
     <Authors>EdenCGD, Gonkers</Authors>
     <Company />
     <Description>.NET client library for accessing the scryfall API, forked from ScryfallAPI.Client</Description>


### PR DESCRIPTION
Version bump to 4.0.0 to represent the new phase of development.
Add 'build' suffix to the version number to mark the NuGet packages built from this version as pre-release.