### PR TITLE
Add GetNamed endpoint

### DIFF
--- a/src/Scryfall.Client/Apis/Cards.cs
+++ b/src/Scryfall.Client/Apis/Cards.cs
@@ -43,4 +43,8 @@ public class Cards : ICards
 
     public Task<Card> GetBySetAndCollectorNumber(string set, int collectorNumber, string language = null) 
         => _restService.GetAsync<Card>($"/cards/{set}/{collectorNumber}{(language == null ? "" : $"/{language}")}");
+
+    public Task<Card> GetByNamed(string name, bool isFuzzy = true, string set = null)
+        => _restService.GetAsync<Card>($"/cards/named?{(isFuzzy ? $"fuzzy={name}" : $"exact={name}")}{(set == null ? "" : $"&set={set}")}");
+    
 }

--- a/src/Scryfall.Client/Apis/ICards.cs
+++ b/src/Scryfall.Client/Apis/ICards.cs
@@ -90,4 +90,13 @@ public interface ICards
     /// <param name="language"></param>
     /// <returns></returns>
     Task<Card> GetBySetAndCollectorNumber(string set, int collectorNumber, string language = null);
+
+    /// <summary>
+    /// Returns a Card based on a name search string.
+    /// </summary>
+    /// <param name="name"></param>
+    /// <param name="isFuzzy">Search for the card using a fuzzy search, if more than one card is found then an exception will be thrown explaining such.</param>
+    /// <param name="set">Refine the search by providing the set code.</param>
+    /// <returns></returns>
+    Task<Card> GetByNamed(string name, bool isFuzzy = true, string set = null);
 }


### PR DESCRIPTION
This PR adds the GetNamed endpoint. This allows users to get a card using a fuzzy or exact name search with an optional set code filter.